### PR TITLE
add AllDomains Tld Parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@metaplex-foundation/js": "^0.19.4",
         "@metaplex-foundation/umi-serializers-encodings": "^0.8.9",
         "@mysten/sui.js": "^0.37.1",
+        "@onsol/tldparser": "^0.6.1",
         "@sei-js/core": "^3.0.1",
         "@sei-js/proto": "^3.0.1",
         "@solana/web3.js": "^1.78.4",
@@ -4789,6 +4790,24 @@
         "yargs-parser": "21.1.1"
       }
     },
+    "node_modules/@onsol/tldparser": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@onsol/tldparser/-/tldparser-0.6.1.tgz",
+      "integrity": "sha512-px/T6umjmnCaLRySeUVyAaf7G5vY1GcbIkNFOw9fc3On5KHvZ7mpzQystYxdBIk1EN09neW0mHjV4XDXjb4CeQ==",
+      "dependencies": {
+        "@ethersproject/sha2": "^5.7.0",
+        "@metaplex-foundation/beet-solana": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.67.0",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "buffer": "6.0.1"
+      }
+    },
     "node_modules/@open-rpc/client-js": {
       "version": "1.8.1",
       "license": "Apache-2.0",
@@ -7500,6 +7519,29 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/blakejs": {
       "version": "1.2.1",
       "license": "MIT"
@@ -7657,7 +7699,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "5.7.1",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.1.tgz",
+      "integrity": "sha512-rVAXBwEcEoYtxnHSO5iWyhzV/O1WMtkUYWlfdLS7FjU4PnSJJHEfHXi/uHPI5EwltmOA794gN3bm3/pzuctWjQ==",
       "funding": [
         {
           "type": "github",
@@ -7672,10 +7716,10 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -7930,6 +7974,29 @@
       "engines": {
         "node": ">=4.0.0",
         "npm": ">=3.0.0"
+      }
+    },
+    "node_modules/cids/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/cids/node_modules/multicodec": {
@@ -13540,6 +13607,29 @@
         "buffer": "^5.5.0"
       }
     },
+    "node_modules/multibase/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/multicodec": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
@@ -13557,6 +13647,29 @@
         "buffer": "^5.5.0",
         "multibase": "^0.7.0",
         "varint": "^5.0.0"
+      }
+    },
+    "node_modules/multihashes/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/multihashes/node_modules/multibase": {
@@ -16274,6 +16387,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/swarm-js/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/swarm-js/node_modules/cacheable-lookup": {
@@ -19246,11 +19382,11 @@
     },
     "packages/core": {
       "name": "@sonarwatch/portfolio-core",
-      "version": "0.8.46"
+      "version": "0.8.47"
     },
     "packages/plugins": {
       "name": "@sonarwatch/portfolio-plugins",
-      "version": "0.8.46"
+      "version": "0.8.47"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@metaplex-foundation/js": "^0.19.4",
     "@metaplex-foundation/umi-serializers-encodings": "^0.8.9",
     "@mysten/sui.js": "^0.37.1",
+    "@onsol/tldparser": "^0.6.1",
     "@sei-js/core": "^3.0.1",
     "@sei-js/proto": "^3.0.1",
     "@solana/web3.js": "^1.78.4",

--- a/packages/core/src/name-service/nameCheckers.ts
+++ b/packages/core/src/name-service/nameCheckers.ts
@@ -54,5 +54,6 @@ export const nameCheckers: NameChecker[] = [
   glowNameChecker,
   avalancheNameChecker,
   aptosNameChecker,
+  // Please leave allDomains at the end.
   allDomainsNameChecker,
 ];

--- a/packages/core/src/name-service/nameCheckers.ts
+++ b/packages/core/src/name-service/nameCheckers.ts
@@ -39,7 +39,7 @@ export const aptosNameChecker: NameChecker = {
   },
 };
 // ## AllDomains
-export const allNameChecker: NameChecker = {
+export const allDomainsNameChecker: NameChecker = {
   addressSystem: AddressSystem.solana,
   checker(name) {
     return name.split(".").length === 2;
@@ -54,5 +54,5 @@ export const nameCheckers: NameChecker[] = [
   glowNameChecker,
   avalancheNameChecker,
   aptosNameChecker,
-  allNameChecker,
+  allDomainsNameChecker,
 ];

--- a/packages/core/src/name-service/nameCheckers.ts
+++ b/packages/core/src/name-service/nameCheckers.ts
@@ -38,6 +38,15 @@ export const aptosNameChecker: NameChecker = {
     return name.endsWith('.apt');
   },
 };
+// ## AllDomains
+export const allNameChecker: NameChecker = {
+  addressSystem: AddressSystem.solana,
+  checker(name) {
+    return name.split(".").length === 2;
+  },
+};
+
+
 
 export const nameCheckers: NameChecker[] = [
   ensNameChecker,
@@ -45,4 +54,5 @@ export const nameCheckers: NameChecker[] = [
   glowNameChecker,
   avalancheNameChecker,
   aptosNameChecker,
+  allNameChecker,
 ];

--- a/packages/plugins/src/utils/name-service/name-service.spec.ts
+++ b/packages/plugins/src/utils/name-service/name-service.spec.ts
@@ -1,5 +1,6 @@
 import { nameService as ensNameService } from './services/ens';
 import { nameService as aptosNameService } from './services/aptos';
+import { nameService as allNameService } from './services/allDomains';
 import { getOwner } from './getOwner';
 
 describe('name-service', () => {
@@ -40,6 +41,30 @@ describe('name-service', () => {
 
     const names2 = await aptosNameService.getNames(
       '0xrand0mfca2b46efb0c9b63e9c92ee31a28b9f22ca52a36967151416706f2ca138c6'
+    );
+    expect(names2.length).toBe(0);
+  });
+
+  it('should getOwner for allDomains', async () => {
+    const owner = await allNameService.getOwner('miester.all');
+    expect(owner).toBe(
+      '2EGGxj2qbNAJNgLCPKca8sxZYetyTjnoRspTPjzN2D67'
+    );
+
+    const owner2 = await allNameService.getOwner(
+      'miaster.all'
+    );
+    expect(owner2).toBe(null);
+  });
+
+  it('should getNames for allDomains', async () => {
+    const names = await allNameService.getNames(
+      '2EGGxj2qbNAJNgLCPKca8sxZYetyTjnoRspTPjzN2D67'
+    );
+    expect(names.some((name) => name === 'miester.abc')).toBe(true);
+
+    const names2 = await aptosNameService.getNames(
+      '11111111111111111111111111111111'
     );
     expect(names2.length).toBe(0);
   });

--- a/packages/plugins/src/utils/name-service/name-service.spec.ts
+++ b/packages/plugins/src/utils/name-service/name-service.spec.ts
@@ -61,7 +61,7 @@ describe('name-service', () => {
     const names = await allDomainsNameService.getNames(
       '2EGGxj2qbNAJNgLCPKca8sxZYetyTjnoRspTPjzN2D67'
     );
-    expect(names.some((name) => name === 'miester.abc')).toBe(true);
+    expect(names.length).toBeGreaterThan(1);
 
     const names2 = await aptosNameService.getNames(
       '11111111111111111111111111111111'

--- a/packages/plugins/src/utils/name-service/name-service.spec.ts
+++ b/packages/plugins/src/utils/name-service/name-service.spec.ts
@@ -1,6 +1,6 @@
 import { nameService as ensNameService } from './services/ens';
 import { nameService as aptosNameService } from './services/aptos';
-import { nameService as allNameService } from './services/allDomains';
+import { nameService as allDomainsNameService } from './services/allDomains';
 import { getOwner } from './getOwner';
 
 describe('name-service', () => {
@@ -46,19 +46,19 @@ describe('name-service', () => {
   });
 
   it('should getOwner for allDomains', async () => {
-    const owner = await allNameService.getOwner('miester.all');
+    const owner = await allDomainsNameService.getOwner('miester.all');
     expect(owner).toBe(
       '2EGGxj2qbNAJNgLCPKca8sxZYetyTjnoRspTPjzN2D67'
     );
 
-    const owner2 = await allNameService.getOwner(
+    const owner2 = await allDomainsNameService.getOwner(
       'miaster.all'
     );
     expect(owner2).toBe(null);
   });
 
   it('should getNames for allDomains', async () => {
-    const names = await allNameService.getNames(
+    const names = await allDomainsNameService.getNames(
       '2EGGxj2qbNAJNgLCPKca8sxZYetyTjnoRspTPjzN2D67'
     );
     expect(names.some((name) => name === 'miester.abc')).toBe(true);

--- a/packages/plugins/src/utils/name-service/nameServices.ts
+++ b/packages/plugins/src/utils/name-service/nameServices.ts
@@ -2,11 +2,12 @@ import { NameService } from './types';
 import { nameService as bonfidaNameService } from './services/bonfida';
 import { nameService as avalancheNameService } from './services/avalanche';
 import { nameService as ensNameService } from './services/ens';
-import { nameService as allNameService } from './services/allDomains';
+import { nameService as allDomainsNameService } from './services/allDomains';
 
 export const nameServices: NameService[] = [
   bonfidaNameService,
   avalancheNameService,
   ensNameService,
-  allNameService,
+  // Please leave allDomainsNameService at the end.
+  allDomainsNameService,
 ];

--- a/packages/plugins/src/utils/name-service/nameServices.ts
+++ b/packages/plugins/src/utils/name-service/nameServices.ts
@@ -2,9 +2,11 @@ import { NameService } from './types';
 import { nameService as bonfidaNameService } from './services/bonfida';
 import { nameService as avalancheNameService } from './services/avalanche';
 import { nameService as ensNameService } from './services/ens';
+import { nameService as allNameService } from './services/allDomains';
 
 export const nameServices: NameService[] = [
   bonfidaNameService,
   avalancheNameService,
   ensNameService,
+  allNameService,
 ];

--- a/packages/plugins/src/utils/name-service/services/allDomains.ts
+++ b/packages/plugins/src/utils/name-service/services/allDomains.ts
@@ -17,7 +17,7 @@ async function getNames(address: string): Promise<string[]> {
   const parser = new TldParser(client);
   const mainDomain = await parser.getMainDomain(address).catch(()=> undefined)
   if (!mainDomain) return [];
-  return [`${mainDomain.domain}.${mainDomain.tld}`];
+  return [`${mainDomain.domain}${mainDomain.tld}`];
 }
 
 export const nameService: NameService = {

--- a/packages/plugins/src/utils/name-service/services/allDomains.ts
+++ b/packages/plugins/src/utils/name-service/services/allDomains.ts
@@ -17,7 +17,6 @@ async function getNames(address: string): Promise<string[]> {
   const parser = new TldParser(client);
   const allDomainsWithNameAccounts = await parser.getParsedAllUserDomains(address).catch(() => undefined)
   if (!allDomainsWithNameAccounts) return [];
-
   return allDomainsWithNameAccounts.map((domainsWithNameAccounts) => domainsWithNameAccounts.domain);;
 }
 

--- a/packages/plugins/src/utils/name-service/services/allDomains.ts
+++ b/packages/plugins/src/utils/name-service/services/allDomains.ts
@@ -1,4 +1,4 @@
-import { allNameChecker } from '@sonarwatch/portfolio-core';
+import { allDomainsNameChecker } from '@sonarwatch/portfolio-core';
 import { getClientSolana } from '../../clients';
 import { NameService } from '../types';
 import { TldParser } from '@onsol/tldparser';
@@ -13,16 +13,16 @@ async function getOwner(name: string): Promise<string | null> {
 
 async function getNames(address: string): Promise<string[]> {
   const client = getClientSolana();
-  
+
   const parser = new TldParser(client);
-  const mainDomain = await parser.getMainDomain(address).catch(()=> undefined)
+  const mainDomain = await parser.getMainDomain(address).catch(() => undefined)
   if (!mainDomain) return [];
   return [`${mainDomain.domain}${mainDomain.tld}`];
 }
 
 export const nameService: NameService = {
   id: 'allDomains',
-  checker: allNameChecker,
+  checker: allDomainsNameChecker,
   getNames,
   getOwner,
 };

--- a/packages/plugins/src/utils/name-service/services/allDomains.ts
+++ b/packages/plugins/src/utils/name-service/services/allDomains.ts
@@ -15,9 +15,10 @@ async function getNames(address: string): Promise<string[]> {
   const client = getClientSolana();
 
   const parser = new TldParser(client);
-  const mainDomain = await parser.getMainDomain(address).catch(() => undefined)
-  if (!mainDomain) return [];
-  return [`${mainDomain.domain}${mainDomain.tld}`];
+  const allDomainsWithNameAccounts = await parser.getParsedAllUserDomains(address).catch(() => undefined)
+  if (!allDomainsWithNameAccounts) return [];
+
+  return allDomainsWithNameAccounts.map((domainsWithNameAccounts) => domainsWithNameAccounts.domain);;
 }
 
 export const nameService: NameService = {

--- a/packages/plugins/src/utils/name-service/services/allDomains.ts
+++ b/packages/plugins/src/utils/name-service/services/allDomains.ts
@@ -1,0 +1,28 @@
+import { allNameChecker } from '@sonarwatch/portfolio-core';
+import { getClientSolana } from '../../clients';
+import { NameService } from '../types';
+import { TldParser } from '@onsol/tldparser';
+
+async function getOwner(name: string): Promise<string | null> {
+  const client = getClientSolana();
+  const parser = new TldParser(client);
+  const owner = await parser.getOwnerFromDomainTld(name)
+  if (owner) return owner.toString();
+  return null;
+}
+
+async function getNames(address: string): Promise<string[]> {
+  const client = getClientSolana();
+  
+  const parser = new TldParser(client);
+  const mainDomain = await parser.getMainDomain(address).catch(()=> undefined)
+  if (!mainDomain) return [];
+  return [`${mainDomain.domain}.${mainDomain.tld}`];
+}
+
+export const nameService: NameService = {
+  id: 'allDomains',
+  checker: allNameChecker,
+  getNames,
+  getOwner,
+};


### PR DESCRIPTION
gm lads,

this PR includes AllDomains TLDs on solana. 

there are currently 20+ TLDs on AllDomains. that is why the nameChecker is checking for if the name is `name.split(".").length === 2;`.

regards,
miester.