### PR TITLE
fix(plugins): zeta airdrop fetcher

### DIFF
--- a/packages/plugins/src/plugins/zeta/airdropFetcher.ts
+++ b/packages/plugins/src/plugins/zeta/airdropFetcher.ts
@@ -41,7 +41,7 @@ const executor: FetcherExecutor = async (owner: string, cache: Cache) => {
     }
   ).catch(() => null);
 
-  if (!res) return [];
+  if (!res || !res.getAirdropFinalFrontend) return [];
 
   const amount = res.getAirdropFinalFrontend.total_allocation;
 


### PR DESCRIPTION
gm sers, this is some awesome work done here, well done. 

just a small contribution, where the zeta airdrop fetcher is failing  

`Cannot read properties of null (reading 'total_allocation')`

hoping to contribute more in the future. 